### PR TITLE
add alias to vhost template

### DIFF
--- a/templates/vhosts.conf.j2
+++ b/templates/vhosts.conf.j2
@@ -9,7 +9,14 @@
 {% endif %}
 
 {% if vhost.documentroot is defined %}
-  DocumentRoot {{ vhost.documentroot }}
+  {% if vhost.virtual_subdir is defined %}
+      DocumentRoot /dev/null
+      Alias "{{ vhost.virtual_subdir }}" "{{ vhost.documentroot }}"
+  {% else %}
+      {% if vhost.documentroot is defined %}
+        DocumentRoot {{ vhost.documentroot }}
+      {% endif %}
+  {% endif %}
 {% endif %}
 
 {% if vhost.serveradmin is defined %}


### PR DESCRIPTION
Was already added long before to split vhost template, now here it is for non-split vhost template.